### PR TITLE
Rationalise output paths

### DIFF
--- a/amf_check_writer/config.py
+++ b/amf_check_writer/config.py
@@ -1,0 +1,8 @@
+# ID of the top level folder in Google Drive
+ROOT_FOLDER_ID = "1TGsJBltDttqs6nsbUwopX5BL_q8AU-5X"
+CURRENT_VERSION = "v2.0"
+NROWS_TO_PARSE = 999
+
+ALL_VERSIONS = (
+    "v1.0", "v1.1", "v2.0"
+)

--- a/amf_check_writer/create_yaml_checks.py
+++ b/amf_check_writer/create_yaml_checks.py
@@ -7,29 +7,37 @@ import os
 import argparse
 
 from amf_check_writer.spreadsheet_handler import SpreadsheetHandler
+from amf_check_writer.config import ALL_VERSIONS, CURRENT_VERSION
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
+
     parser.add_argument(
-        "spreadsheets_dir",
-        help="Directory containing spreadsheet data, as produced by "
-             "download_from_drive.py"
+        "-s", "--source-dir", required=True,
+        help="Source directory, as downloaded and produced by "
+             "`download-from-drive` script."
     )
+
     parser.add_argument(
-        "output_dir",
-        help="Directory to write output YAML files to"
+        "-v", "--version", required=True, choices=ALL_VERSIONS,
+        help=f"Version of the spreadsheets to use (e.g. '{CURRENT_VERSION}')."
     )
+
     args = parser.parse_args(sys.argv[1:])
 
-    if not os.path.isdir(args.spreadsheets_dir):
-        parser.error("No such directory '{}'".format(args.spreadsheets_dir))
-    if not os.path.isdir(args.output_dir):
-        os.mkdir(args.output_dir)
+    if not os.path.isdir(args.source_dir):
+        parser.error(f"No such directory '{args.source_dir}'")
 
-    args.spreadsheets_dir = os.path.join(args.spreadsheets_dir, 'product-definitions')
-    sh = SpreadsheetHandler(args.spreadsheets_dir)
-    sh.write_yaml(args.output_dir)
+    version_dir = os.path.join(args.source_dir, args.version)
+    sh = SpreadsheetHandler(version_dir)
+
+    checks_dir = os.path.join(version_dir, "checks")
+    if not os.path.isdir(checks_dir): 
+        os.makedirs(checks_dir)
+
+    sh.write_yaml(checks_dir)
+
 
 if __name__ == "__main__":
     main()

--- a/amf_check_writer/cvs/instruments.py
+++ b/amf_check_writer/cvs/instruments.py
@@ -15,7 +15,7 @@ class InstrumentsCV(BaseCV):
             instr_id = row["New Instrument Name"]
 
             if instr_id in cv[ns]:
-                print(f"[WARNING] Duplicate instrument name '{insr_id}'", file=sys.stderr)
+                print(f"[WARNING] Duplicate instrument name '{instr_id}'", file=sys.stderr)
                 continue
 
             prev_ids = row["Old Instrument Name"] or []

--- a/amf_check_writer/cvs/instruments.py
+++ b/amf_check_writer/cvs/instruments.py
@@ -6,21 +6,25 @@ from amf_check_writer.cvs.base import BaseCV
 
 
 class InstrumentsCV(BaseCV):
+
     def parse_tsv(self, reader):
         ns = self.namespace
         cv = {ns: OrderedDict()}
+
         for row in reader:
             instr_id = row["New Instrument Name"]
+
             if instr_id in cv[ns]:
-                print("WARNING: Duplicate instrument name '{}'".format(instr_id),
-                      file=sys.stderr)
+                print(f"[WARNING] Duplicate instrument name '{insr_id}'", file=sys.stderr)
                 continue
 
-            prev_ids = filter(None, map(str.strip,
-                                        row["Old Instrument Name"].split(",")))
+            prev_ids = row["Old Instrument Name"] or []
+            if prev_ids:
+                prev_ids = [iname.strip() for iname in prev_ids.split(",")]
+
             cv[ns][instr_id] = {
                 "instrument_id": instr_id,
-                "previous_instrument_ids": list(prev_ids),
+                "previous_instrument_ids": prev_ids,
                 "description": row["Descriptor"]
             }
         return cv

--- a/amf_check_writer/pyessv_writer.py
+++ b/amf_check_writer/pyessv_writer.py
@@ -42,8 +42,10 @@ class PyessvWriter(object):
         self.term_regex = r"^[a-z0-9\-@\.]*$"
 
     def write_cvs(self, cvs):
-        print("Writing to pyessv archive...")
+        print("[INFO] Writing to pyessv archive...")
         for cv in cvs:
+
+            print(f"[INFO] Working on: {cv.namespace}")
             collection = self._pyessv.create_collection(
                 self.scope_amf,
                 cv.namespace,
@@ -67,3 +69,4 @@ class PyessvWriter(object):
                                          create_date=self.create_date,
                                          **kwargs)
             self._pyessv.archive(self.authority)
+

--- a/amf_check_writer/spreadsheet_handler.py
+++ b/amf_check_writer/spreadsheet_handler.py
@@ -220,6 +220,7 @@ class SpreadsheetHandler(object):
                 continue
 
             full_path = os.path.join(self.path, path)
+
             if not self._isfile(full_path):
                 continue
 
@@ -278,17 +279,17 @@ class SpreadsheetHandler(object):
         Return iterator of CVParseInfo objects for common variable/dimension
         CVs
         """
-        common_dir = os.path.join(self.path, 'product-definitions/tsv', SPREADSHEET_NAMES["common_spreadsheet"])
+        common_dir = os.path.join('product-definitions/tsv', SPREADSHEET_NAMES["common_spreadsheet"])
 
         for prefix, obj in self.VAR_DIM_FILENAME_MAPPING.items():
 
             for mode in DeploymentModes:
                 dep_m = mode.value
                 if prefix == 'global-attributes':
-                    filename = "{type}.tsv".format(type=prefix)
+                    filename = f"{prefix}.tsv"
                     print("NOTE: Global attributes are the same for all deployment modes.")
                 else:
-                    filename = "{type}-{dep_m}.tsv".format(type=prefix, dep_m=dep_m)
+                    filename = f"{prefix}-{dep_m}.tsv"
 
                 yield CVParseInfo(
                     path=os.path.join(common_dir, filename),
@@ -305,8 +306,8 @@ class SpreadsheetHandler(object):
         """
         isfile = os.path.isfile(path)
         if not isfile:
-            print("[WARNING] Expected to find file at '{}'".format(path),
-                  file=sys.stderr)
+            print(f"[WARNING] Expected to find file at '{path}'", file=sys.stderr)
+
         return isfile
 
     def _find_version_number(self, s):

--- a/amf_check_writer/yaml_check.py
+++ b/amf_check_writer/yaml_check.py
@@ -10,6 +10,7 @@ from amf_check_writer.exceptions import InvalidRowError
 from amf_check_writer.base_file import AmfFile
 from amf_check_writer.cvs.base import StripWhitespaceReader
 
+
 class CustomDumper(yaml.SafeDumper):
     # Inserts blank lines between top-level objects: inspired by https://stackoverflow.com/a/44284819/3786245"
     # Preserve the mapping key order. See https://stackoverflow.com/a/52621703/1497385"
@@ -24,6 +25,7 @@ class CustomDumper(yaml.SafeDumper):
 
 CustomDumper.add_representer(OrderedDict, CustomDumper.represent_dict_preserve_order)
 
+
 class YamlCheck(AmfFile):
     """
     A YAML file that can be used with cc-yaml to run a suite of checks
@@ -35,7 +37,7 @@ class YamlCheck(AmfFile):
         """
         d = OrderedDict()
 
-        d["suite_name"] = "{}_checks:{}".format(self.namespace,version)
+        d["suite_name"] = f"{self.namespace}_checks:{version}"
         d["description"] = "Check '{}' in AMF files".format(" ".join(self.facets))
         d["checks"] = list(self.get_yaml_checks())
 
@@ -123,7 +125,7 @@ class GlobalAttrCheck(YamlCheck):
         for row in reader:
             name_id = row["Name"]
             if name_id in cv[ns]:
-                print("WARNING: Duplicate global attribute '{}'".format(name_id),
+                print(f"[WARNING] Duplicate global attribute '{name_id}'",
                       file=sys.stderr)
                 continue
 
@@ -151,7 +153,7 @@ class GlobalAttrCheck(YamlCheck):
         check_name = "checklib.register.nc_file_checks_register.GlobalAttrRegexCheck"
         for attr, regex in self.regexes.items():
             yield {
-                "check_id": "check_{}_global_attribute".format(attr),
+                "check_id": f"check_{attr}_global_attribute",
                 "check_name": check_name,
                 "parameters": {"attribute": attr, "regex": regex}
             }


### PR DESCRIPTION
- switched to use common input/output paths for checks, vocabs, spreadsheets etc.
- also added: `amf_check_writer/config.py` module for common configurations.