### PR TITLE
Updated command-line and moved to single import

### DIFF
--- a/amf-check-workflow.md
+++ b/amf-check-workflow.md
@@ -1,5 +1,6 @@
 # Workflow diagram for AMF Check Writer: Checks and Vocabularies
 
+
 ## Content from the Google Drive
 
 The initial content is loaded from the versioned spreadsheets held on the AMOF Google Drive. The downloaded versions are published in the http://github.com/ncasuk/AMF_CVs repository.
@@ -15,6 +16,7 @@ dimensions-air | file-naming |
 variables-air |  | 
 dimensions-sea |  | 
 variables-sea |  | 
+
 ## YAML checks
 
 The YAML checks are generated from the CSV version of the worksheets saved from the Google Drive spreadsheets. These are published in the http://github.com/ncasuk/amf-compliance-checks repository.
@@ -36,6 +38,7 @@ AMF_product_common_variable_trajectory.yml |
 AMF_file_info.yml | 
 AMF_file_structure.yml | 
 AMF_global_attrs.yml | 
+
 ## Controlled vocabularies (in JSON format)
 
 A set of controlled vocabularies are generated from the spreadsheet data. These are written as JSON files and are published in the https://github.com/ncasuk/AMF_CVs repository.
@@ -59,6 +62,7 @@ AMF_product_common_global-attributes_land.json |
 AMF_product_common_global-attributes_sea.json | 
 AMF_product_common_global-attributes_air.json | 
 AMF_product_common_global-attributes_trajectory.json | 
+
 ## Controlled vocabularies (in PYESSV format)
 
 A set of controlled vocabularies are generated from the spreadsheet data. These are written as PYESSV files and are published in the https://github.com/ncasuk/AMF_CVs repository.
@@ -84,3 +88,5 @@ product-common-variable-air |
 product-common-variable-land | 
 product-common-variable-sea | 
 product-common-variable-trajectory | 
+
+

--- a/amf_check_writer/create_cvs.py
+++ b/amf_check_writer/create_cvs.py
@@ -32,7 +32,7 @@ def main():
     sh = SpreadsheetHandler(version_dir)
 
     cvs_dir = os.path.join(version_dir, "AMF_CVs")
-    pyessv_dir = os.path.join(version_dir, "pyessv-vocabs")
+    pyessv_dir = os.path.join(version_dir, "amf-pyessv-vocabs")
 
     for dr in (cvs_dir, pyessv_dir):
         if not os.path.isdir(dr):

--- a/amf_check_writer/create_yaml_checks.py
+++ b/amf_check_writer/create_yaml_checks.py
@@ -32,7 +32,7 @@ def main():
     version_dir = os.path.join(args.source_dir, args.version)
     sh = SpreadsheetHandler(version_dir)
 
-    checks_dir = os.path.join(version_dir, "checks")
+    checks_dir = os.path.join(version_dir, "amf-checks")
     if not os.path.isdir(checks_dir): 
         os.makedirs(checks_dir)
 

--- a/amf_check_writer/workflow_docs.py
+++ b/amf_check_writer/workflow_docs.py
@@ -58,7 +58,7 @@ def fmt_table(dct):
 
 def fmt_section(dct):
     text = dct["text"].replace("[NEW_PARA]", "\n\n")
-    md = f"## {dct['header']}\n\n{text}\n\n"
+    md = f"\n## {dct['header']}\n\n{text}\n\n"
     md += fmt_table(dct)
     return md
 
@@ -81,7 +81,7 @@ def write_workflow_doc():
 
     output_file = os.path.join(OUTPUT_DIR, 'amf-check-workflow.md')
     with open(output_file, "w") as writer:
-        writer.write(markdown)
+        writer.write(markdown + "\n\n")
 
     print(f"[INFO] Wrote workflow to: {output_file}")
  

--- a/install-checker-suite.sh
+++ b/install-checker-suite.sh
@@ -52,7 +52,7 @@ for pkg in $PACKAGES; do
 done
 
 echo "[INFO] Create setup file..."
-PYESSV_ARCHIVE_HOME=$CHECKS_BASE_DIR/AMF_CVs-${CV_VERSIONS}/pyessv-vocabs
+PYESSV_ARCHIVE_HOME=$CHECKS_BASE_DIR/AMF_CVs-${CV_VERSIONS}/amf-pyessv-vocabs
 CHECKS_DIR=$CHECKS_BASE_DIR/amf-compliance-checks-${CV_VERSIONS}/amf-checks
 
 setup_file=${CHECKS_BASE_DIR}/setup-checks-env.sh

--- a/install-checker-suite.sh
+++ b/install-checker-suite.sh
@@ -53,7 +53,7 @@ done
 
 echo "[INFO] Create setup file..."
 PYESSV_ARCHIVE_HOME=$CHECKS_BASE_DIR/AMF_CVs-${CV_VERSIONS}/pyessv-vocabs
-CHECKS_DIR=$CHECKS_BASE_DIR/amf-compliance-checks-${CV_VERSIONS}/checks
+CHECKS_DIR=$CHECKS_BASE_DIR/amf-compliance-checks-${CV_VERSIONS}/amf-checks
 
 setup_file=${CHECKS_BASE_DIR}/setup-checks-env.sh
 


### PR DESCRIPTION
- ensured that command-line argument for "-f"/"--format" is passed through
- instead of calling out to "compliance-checker" as a script we moved to
  importing `cchecker` and running `cchecker.main()`. This means that all
  imports, including load of PYESSV files, only happens once.