### PR TITLE
Google Drive related updates

### DIFF
--- a/amf_check_writer/config.py
+++ b/amf_check_writer/config.py
@@ -10,7 +10,7 @@ NROWS_TO_PARSE = 999
 PRODUCT_COUNT_MINIMUM = 50
 
 ALL_VERSIONS = (
-    "v1.0", "v1.1", "v2.0"
+    "v1.0", "v1.1", "v2.0", "v2.1a"
 )
 
 ALL_VOCABS = (

--- a/amf_check_writer/config.py
+++ b/amf_check_writer/config.py
@@ -4,12 +4,17 @@ import site
 # ID of the top level folder in Google Drive
 SHARED_DRIVE_ID = "0AEZ8wCGEWktfUk9PVA"
 GENERAL_PRODUCTS_FOLDER_ID = "1TGsJBltDttqs6nsbUwopX5BL_q8AU-5X"
+VOCABS_FOLDER_ID = "1043BtxPQ3arRxjHuYCGu2oHbpOdePepT"
 CURRENT_VERSION = "v2.0"
 NROWS_TO_PARSE = 999
 PRODUCT_COUNT_MINIMUM = 50
 
 ALL_VERSIONS = (
     "v1.0", "v1.1", "v2.0"
+)
+
+ALL_VOCABS = (
+    "instruments",
 )
 
 

--- a/amf_check_writer/config.py
+++ b/amf_check_writer/config.py
@@ -2,7 +2,8 @@ import os
 import site
 
 # ID of the top level folder in Google Drive
-ROOT_FOLDER_ID = "1TGsJBltDttqs6nsbUwopX5BL_q8AU-5X"
+SHARED_DRIVE_ID = "0AEZ8wCGEWktfUk9PVA"
+GENERAL_PRODUCTS_FOLDER_ID = "1TGsJBltDttqs6nsbUwopX5BL_q8AU-5X"
 CURRENT_VERSION = "v2.0"
 NROWS_TO_PARSE = 999
 PRODUCT_COUNT_MINIMUM = 50

--- a/amf_check_writer/config.py
+++ b/amf_check_writer/config.py
@@ -15,6 +15,7 @@ ALL_VERSIONS = (
 
 ALL_VOCABS = (
     "instruments",
+    "platforms",
 )
 
 

--- a/amf_check_writer/config.py
+++ b/amf_check_writer/config.py
@@ -10,7 +10,7 @@ NROWS_TO_PARSE = 999
 PRODUCT_COUNT_MINIMUM = 50
 
 ALL_VERSIONS = (
-    "v1.0", "v1.1", "v2.0", "v2.1a"
+    "v1.0", "v1.1", "v2.0", "v2.1"
 )
 
 ALL_VOCABS = (

--- a/amf_check_writer/config.py
+++ b/amf_check_writer/config.py
@@ -10,7 +10,7 @@ NROWS_TO_PARSE = 999
 PRODUCT_COUNT_MINIMUM = 50
 
 ALL_VERSIONS = (
-    "v1.0", "v1.1", "v2.0", "v2.1"
+    "v1.0", "v1.1", "v2.0", "v2.1", "v2.2"
 )
 
 ALL_VOCABS = (

--- a/amf_check_writer/create_cvs.py
+++ b/amf_check_writer/create_cvs.py
@@ -7,7 +7,7 @@ import sys
 import argparse
 
 from amf_check_writer.spreadsheet_handler import SpreadsheetHandler
-from amf_check_writer.config import ALL_VERSIONS, CURRENT_VERSION
+from amf_check_writer.config import ALL_VERSIONS, CURRENT_VERSION, ALL_VOCABS
 
 
 def main():
@@ -19,27 +19,39 @@ def main():
     )
 
     parser.add_argument(
-        "-v", "--version", required=True, choices=ALL_VERSIONS,
+        "-v", "--version", choices=ALL_VERSIONS,
         help=f"Version of the spreadsheets to use (e.g. '{CURRENT_VERSION}')."
+    )
+
+    parser.add_argument(
+        "-c",
+        "--vocab",
+        choices = ALL_VOCABS,
+        help = "Specific vocabulary to download",
+        default = None,
     )
 
     args = parser.parse_args(sys.argv[1:])
 
+    if (not args.version and not args.vocab) or (args.version and args.vocab):
+        msg = "One and only one of -v/--version and -c/--vocab must be specified"
+        parser.error(msg)
+
     if not os.path.isdir(args.source_dir):
         parser.error(f"No such directory '{args.source_dir}'")
 
-    version_dir = os.path.join(args.source_dir, args.version)
-    sh = SpreadsheetHandler(version_dir)
+    if args.version:
+        version_dir = os.path.join(args.source_dir, args.version)
+    else:
+        version_dir = os.path.join(args.source_dir, f"vocabs/{args.vocab}")
+    sh = SpreadsheetHandler(version_dir, "version" if args.version else args.vocab)
 
     cvs_dir = os.path.join(version_dir, "AMF_CVs")
-    pyessv_dir = os.path.join(version_dir, "amf-pyessv-vocabs")
 
-    for dr in (cvs_dir, pyessv_dir):
-        if not os.path.isdir(dr):
-            os.makedirs(dr)
+    if not os.path.isdir(cvs_dir):
+        os.makedirs(cvs_dir)
 
-    sh.write_cvs(cvs_dir, write_pyessv=True,
-                 pyessv_root=pyessv_dir)
+    sh.write_cvs(cvs_dir, write_pyessv=False)
 
 
 

--- a/amf_check_writer/cvs/instruments.py
+++ b/amf_check_writer/cvs/instruments.py
@@ -25,6 +25,7 @@ class InstrumentsCV(BaseCV):
             cv[ns][instr_id] = {
                 "instrument_id": instr_id,
                 "previous_instrument_ids": prev_ids,
-                "description": row["Descriptor"]
+                "description": row["Descriptor"],
+                "instrument_pid": row["PID"] or ""
             }
         return cv

--- a/amf_check_writer/cvs/instruments.py
+++ b/amf_check_writer/cvs/instruments.py
@@ -25,7 +25,7 @@ class InstrumentsCV(BaseCV):
             cv[ns][instr_id] = {
                 "instrument_id": instr_id,
                 "previous_instrument_ids": prev_ids,
-                "description": row["Descriptor"],
-                "instrument_pid": row["PID"] or ""
+                "description": row["Descriptor"]#,
+#                "instrument_pid": row["PID"] or ""
             }
         return cv

--- a/amf_check_writer/download_from_drive.py
+++ b/amf_check_writer/download_from_drive.py
@@ -55,7 +55,7 @@ def api_call(func):
 
     def inner(*args, **kwargs):
         # Rate limit is 'max_request' requests per 'min_time' seconds
-        max_requests = 20
+        max_requests = 30
         min_time = 120
 
         now = time.time()

--- a/amf_check_writer/download_from_drive.py
+++ b/amf_check_writer/download_from_drive.py
@@ -11,7 +11,6 @@ import argparse
 from pathlib import Path
 
 import httplib2
-from pygdrive3 import service
 
 from apiclient import discovery
 from apiclient import http

--- a/amf_check_writer/download_from_drive.py
+++ b/amf_check_writer/download_from_drive.py
@@ -19,31 +19,31 @@ from apiclient import http
 
 from amf_check_writer.credentials import get_credentials
 from amf_check_writer.workflow_docs import read_workflow_data
-from amf_check_writer.config import (CURRENT_VERSION, ROOT_FOLDER_ID, 
-           PRODUCT_COUNT_MINIMUM, ALL_VERSIONS, NROWS_TO_PARSE)
-
-
-SPREADSHEET_MIME_TYPES = (
-    "application/vnd.google-apps.spreadsheet"
+from amf_check_writer.config import (
+    CURRENT_VERSION,
+    SHARED_DRIVE_ID,
+    GENERAL_PRODUCTS_FOLDER_ID,
+    PRODUCT_COUNT_MINIMUM,
+    ALL_VERSIONS,
+    NROWS_TO_PARSE,
 )
+
+
+SPREADSHEET_MIME_TYPES = "application/vnd.google-apps.spreadsheet"
 
 FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
 
-FOLDERS_TO_SKIP = (
-    "products under development",
-    "TO_DELETE_SOON",
-    "Archive_1"
-)
+FOLDERS_TO_SKIP = ("products under development", "TO_DELETE_SOON", "Archive_1")
 
 API_CALL_TIMES = []
 
 # Load information about which spreadsheets/worksheets are expected
-workflow_data = {k: v for k,v in read_workflow_data()['google_drive_content'].items()}
+workflow_data = {k: v for k, v in read_workflow_data()["google_drive_content"].items()}
 ALLOWED_WORKSHEET_NAMES = {
-    worksheet.strip("*") for section in ["_common.xlsx", "_vocabularies.xlsx", "per-product"]
+    worksheet.strip("*")
+    for section in ["_common.xlsx", "_vocabularies.xlsx", "per-product"]
     for worksheet in workflow_data[section]
 }
-
 
 
 def api_call(func):
@@ -51,6 +51,7 @@ def api_call(func):
     Decorator for functions that make a call to one of Google's APIs. Used to
     avoid hitting rate limits
     """
+
     def inner(*args, **kwargs):
         # Rate limit is 'max_request' requests per 'min_time' seconds
         max_requests = 20
@@ -65,8 +66,12 @@ def api_call(func):
 
         # If 100 or more then wait long enough to make this next request
         if len(API_CALL_TIMES) >= max_requests:
-            n = min_time - now + API_CALL_TIMES[0] + 2 # Add 2s leeway...
-            print("[WARNING] Waiting {} seconds to avoid reaching rate limit...".format(int(n)))
+            n = min_time - now + API_CALL_TIMES[0] + 2  # Add 2s leeway...
+            print(
+                "[WARNING] Waiting {} seconds to avoid reaching rate limit...".format(
+                    int(n)
+                )
+            )
             time.sleep(n)
 
         API_CALL_TIMES.append(time.time())
@@ -94,34 +99,44 @@ class SheetDownloader(object):
 
         # Authenticate and get API handles
         drive_credentials = get_credentials("drive", secrets_file)
-        drive_http = drive_credentials.authorize(httplib2.Http())
-        self.drive_api = discovery.build("drive", "v3", http=drive_http)
+        self.drive_api = discovery.build("drive", "v3", credentials=drive_credentials)
 
         sheets_credentials = get_credentials("sheets", secrets_file)
-        sheets_http = sheets_credentials.authorize(httplib2.Http())
-        discovery_url = ("https://sheets.googleapis.com/$discovery/rest?version=v4")
-        self.sheets_api = discovery.build("sheets", "v4", http=sheets_http,
-                                          discoveryServiceUrl=discovery_url)
+        discovery_url = "https://sheets.googleapis.com/$discovery/rest?version=v4"
+        self.sheets_api = discovery.build(
+            "sheets",
+            "v4",
+            credentials=drive_credentials,
+            discoveryServiceUrl=discovery_url,
+        )
 
         # # Also authenticate to separate downloder library for raw XLSX downloads
         # # This isn't currently working, so using the above API handle.
         # drive_service = service.DriveService(self.secrets_file)
         # drive_service.auth()
- 
+
         # self.drive_service = drive_service.drive_service
 
     def run(self):
         self.find_all_spreadsheets(self.save_spreadsheet_callback())
 
     @api_call
-    def get_folder_children(self, folder_id):
+    def get_folder_children(self, shared_drive_id, folder_id):
         """
         Return a list of children of the Drive folder with the given ID
         """
-        results = (self.drive_api.files().list(
-            fields="files(id, name, mimeType)",
-            q="'{}' in parents".format(folder_id)
-        ).execute())
+        results = (
+            self.drive_api.files()
+            .list(
+                fields="files(id, name, mimeType)",
+                corpora="drive",
+                driveId=shared_drive_id,
+                includeItemsFromAllDrives=True,
+                supportsAllDrives=True,
+                q="'{}' in parents".format(folder_id),
+            )
+            .execute()
+        )
         return results.get("files", [])
 
     @api_call
@@ -130,24 +145,35 @@ class SheetDownloader(object):
 
     @api_call
     def get_sheet_values(self, sheet_id, cell_range):
-        results = self.sheets_api.spreadsheets().values().get(spreadsheetId=sheet_id,
-                                                              range=cell_range).execute()
+        results = (
+            self.sheets_api.spreadsheets()
+            .values()
+            .get(spreadsheetId=sheet_id, range=cell_range)
+            .execute()
+        )
         return results.get("values", [])
 
     @api_call
     def save_raw_spreadsheet(self, sheet_id, spreadsheet_file):
-        request = self.drive_api.files().export_media(fileId=sheet_id,
-              mimeType='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+        request = self.drive_api.files().export_media(
+            fileId=sheet_id,
+            mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
 
-        with open(spreadsheet_file, 'wb') as fh:
+        with open(spreadsheet_file, "wb") as fh:
             downloader = http.MediaIoBaseDownload(fh, request)
 
             done = False
             while done is False:
                 status, done = downloader.next_chunk()
-        
 
-    def find_all_spreadsheets(self, callback, root_id=ROOT_FOLDER_ID, folder_name=""):
+    def find_all_spreadsheets(
+        self,
+        callback,
+        shared_drive_id=SHARED_DRIVE_ID,
+        root_id=GENERAL_PRODUCTS_FOLDER_ID,
+        folder_name="",
+    ):
         """
         Recursively search the drive folder with the given ID and call `callback`
         on each spreadsheet found. `callback` is called with args
@@ -155,8 +181,7 @@ class SheetDownloader(object):
         """
         fnames = []
 
-        for f in self.get_folder_children(root_id):
-
+        for f in self.get_folder_children(shared_drive_id, root_id):
             fname = f["name"]
             fnames.append(fname)
 
@@ -164,17 +189,21 @@ class SheetDownloader(object):
                 if fname in FOLDERS_TO_SKIP:
                     print(f"[INFO] Skipping folder '{fname}'")
                     continue
-                
+
                 if fname in self.version:
                     print(f"[INFO] Found and using '{fname}'")
                 else:
-                    print(f"[INFO] Skipping folder with '{fname}' as we want '{self.version}'")
+                    print(
+                        f"[INFO] Skipping folder with '{fname}' as we want '{self.version}'"
+                    )
                     continue
 
                 new_folder = os.path.join(folder_name, fname)
 
                 # Make the recursive call if we have found a sub-folder
-                self.find_all_spreadsheets(callback, root_id=f["id"], folder_name=new_folder)
+                self.find_all_spreadsheets(
+                    callback, root_id=f["id"], folder_name=new_folder
+                )
 
             elif f["mimeType"] in SPREADSHEET_MIME_TYPES:
                 # Process the spreadsheet
@@ -185,13 +214,17 @@ class SheetDownloader(object):
             expected_xlsx = {xlsx for xlsx in workflow_data if xlsx.endswith(".xlsx")}
             if not expected_xlsx.issubset(set(fnames)):
                 diff = expected_xlsx.difference(fnames)
-                raise ValueError(f"[ERROR] The following expected spreadsheets were not found on "
-                                 f"Google Drive: {diff}")
+                raise ValueError(
+                    f"[ERROR] The following expected spreadsheets were not found on "
+                    f"Google Drive: {diff}"
+                )
 
             if len(fnames) < PRODUCT_COUNT_MINIMUM:
-                raise Exception(f"[ERROR] The number of product spreadsheets found is less than "
-                                f"the minimum expected: {len(fnames)} < {PRODUCT_COUNT_MINIMUM}."
-                                f" Please investigate.")
+                raise Exception(
+                    f"[ERROR] The number of product spreadsheets found is less than "
+                    f"the minimum expected: {len(fnames)} < {PRODUCT_COUNT_MINIMUM}."
+                    f" Please investigate."
+                )
 
     def write_values_to_tsv(self, values, out_file):
         """
@@ -200,8 +233,14 @@ class SheetDownloader(object):
         """
         with open(out_file, "w") as f:
             for row in values:
-                f.write("\t".join([cell.strip().replace("\n", "|").replace("\r", "")
-                                   for cell in row]))
+                f.write(
+                    "\t".join(
+                        [
+                            cell.strip().replace("\n", "|").replace("\r", "")
+                            for cell in row
+                        ]
+                    )
+                )
                 f.write(os.linesep)
 
     def download_all_sheets(self, sheet_id, sheet_name):
@@ -209,7 +248,7 @@ class SheetDownloader(object):
         Download each sheet of a spreadsheet as a TSV file and save them to an
         output directory.
 
-        Also download the raw spreadsheet and save that 
+        Also download the raw spreadsheet and save that
 
         Spreadsheets are saved in two formats in the following structure:
 
@@ -220,22 +259,28 @@ class SheetDownloader(object):
         # Get spreadsheet as a whole and iterate through each sheet
         results = self.get_spreadsheet(sheet_id)
 
-        print("[INFO] Saving {} sheets to {}...".format(len(results["sheets"]), self.out_dir))
+        print(
+            "[INFO] Saving {} sheets to {}...".format(
+                len(results["sheets"]), self.out_dir
+            )
+        )
         sheet_name_no_xlsx = sheet_name[:-5]
-        
-        # Validate sheet name
-        if sheet_name_no_xlsx + '.xlsx' != sheet_name:
-            raise Exception(f"[ERROR] Sheet does not have expected name with '.xlsx' extension: {sheet_name}")
 
-        prod_def_dir = os.path.join(self.out_dir, 'product-definitions')
-        tsv_dir = os.path.join(prod_def_dir, 'tsv', sheet_name_no_xlsx)
-        spreadsheet_dir = os.path.join(prod_def_dir, 'spreadsheet')
-        
+        # Validate sheet name
+        if sheet_name_no_xlsx + ".xlsx" != sheet_name:
+            raise Exception(
+                f"[ERROR] Sheet does not have expected name with '.xlsx' extension: {sheet_name}"
+            )
+
+        prod_def_dir = os.path.join(self.out_dir, "product-definitions")
+        tsv_dir = os.path.join(prod_def_dir, "tsv", sheet_name_no_xlsx)
+        spreadsheet_dir = os.path.join(prod_def_dir, "spreadsheet")
+
         for sdir in (tsv_dir, spreadsheet_dir):
             if not os.path.isdir(sdir):
                 os.makedirs(sdir)
 
-        print('[INFO] Saving TSV files to: {}...'.format(tsv_dir))
+        print("[INFO] Saving TSV files to: {}...".format(tsv_dir))
         worksheets = set()
 
         for sheet in results["sheets"]:
@@ -244,38 +289,50 @@ class SheetDownloader(object):
 
             # Check worksheet name is valid
             if name not in ALLOWED_WORKSHEET_NAMES:
-                print('[ERROR] Worksheet name not recognised: {}'.format(name))
+                print("[ERROR] Worksheet name not recognised: {}".format(name))
 
             cell_range = "'{}'!A1:Z{}".format(name, NROWS_TO_PARSE)
             out_file = os.path.join(tsv_dir, "{}.tsv".format(name))
 
             if os.path.isfile(out_file) and not self.regenerate:
-                print(f"[WARNING] Not regenerating TSV...file already exists: {out_file}")
+                print(
+                    f"[WARNING] Not regenerating TSV...file already exists: {out_file}"
+                )
             else:
-                self.write_values_to_tsv(self.get_sheet_values(sheet_id, cell_range), out_file)
+                self.write_values_to_tsv(
+                    self.get_sheet_values(sheet_id, cell_range), out_file
+                )
 
         # Check the expected worksheet files were processed
         # For general (relating to all products) spreadsheets
         if sheet_name.startswith("_"):
             if not set(workflow_data[sheet_name]) == worksheets:
-                raise Exception(f"[ERROR] Could not find/process all expected worksheets for "
-                                f"spreadsheet '{sheet_name}'. Difference is:\n"
-                                f"\tExpected: {sorted(workflow_data[sheet_name])}\n"
-                                f"\tFound:    {sorted(worksheets)}")
+                raise Exception(
+                    f"[ERROR] Could not find/process all expected worksheets for "
+                    f"spreadsheet '{sheet_name}'. Difference is:\n"
+                    f"\tExpected: {sorted(workflow_data[sheet_name])}\n"
+                    f"\tFound:    {sorted(worksheets)}"
+                )
 
         # For product-specific spreadsheets
         else:
-            required = {wsheet for wsheet in workflow_data["per-product"] if "*" not in wsheet}
+            required = {
+                wsheet for wsheet in workflow_data["per-product"] if "*" not in wsheet
+            }
 
-            if not required.issubset(worksheets): 
-                raise Exception(f"[ERROR] Could not find/process product-specific worksheets "
-                                f"for '{sheet_name}'. Missing: {required.difference(worksheets)}") 
-       
-        # Now download the raw spreadsheet 
+            if not required.issubset(worksheets):
+                raise Exception(
+                    f"[ERROR] Could not find/process product-specific worksheets "
+                    f"for '{sheet_name}'. Missing: {required.difference(worksheets)}"
+                )
+
+        # Now download the raw spreadsheet
         spreadsheet_file = os.path.join(spreadsheet_dir, sheet_name)
 
         if os.path.isfile(spreadsheet_file) and not self.regenerate:
-            print(f"[WARNING] Download not initiated...file already exists: {spreadsheet_file}")
+            print(
+                f"[WARNING] Download not initiated...file already exists: {spreadsheet_file}"
+            )
             return
         else:
             print(f"[INFO] Saving spreadsheet to: {spreadsheet_file}...")
@@ -287,42 +344,50 @@ class SheetDownloader(object):
         and saves sheets to a directory under `self.out_dir`.
 
         """
+
         def callback(name, sheet_id, parent_folder):
             self.download_all_sheets(sheet_id, name)
 
         return callback
 
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "output_dir",
-        help="Directory to write spreadsheets to"
-    )
+    parser.add_argument("output_dir", help="Directory to write spreadsheets to")
 
     parser.add_argument(
-        "-s", "--secrets",
+        "-s",
+        "--secrets",
         help="Client secrets JSON file (see README for instructions on how to "
-             "obtain this). Only required for first time use."
+        "obtain this). Only required for first time use.",
     )
 
     parser.add_argument(
-        "-v", "--version", required=True, choices=ALL_VERSIONS,
-        help=f"Version of the spreadsheets to use (e.g. '{CURRENT_VERSION}')."
+        "-v",
+        "--version",
+        required=True,
+        choices=ALL_VERSIONS,
+        help=f"Version of the spreadsheets to use (e.g. '{CURRENT_VERSION}').",
     )
 
     parser.add_argument(
-        "--regenerate", dest="regenerate", action="store_true",
+        "--regenerate",
+        dest="regenerate",
+        action="store_true",
         help="Force download and re-generation of files that already exist on "
-             "the file system. Default is to always re-generate files."
+        "the file system. Default is to always re-generate files.",
     )
-    parser.add_argument(
-        "--no-regenerate", dest="regenerate", action="store_false"
-    )
+    parser.add_argument("--no-regenerate", dest="regenerate", action="store_false")
 
     args = parser.parse_args(sys.argv[1:])
-    downloader = SheetDownloader(args.output_dir, args.version, secrets_file=args.secrets,
-                                 regenerate=args.regenerate)
+    downloader = SheetDownloader(
+        args.output_dir,
+        args.version,
+        secrets_file=args.secrets,
+        regenerate=args.regenerate,
+    )
     downloader.run()
+
 
 if __name__ == "__main__":
     main()

--- a/amf_check_writer/download_from_drive.py
+++ b/amf_check_writer/download_from_drive.py
@@ -55,7 +55,7 @@ def api_call(func):
 
     def inner(*args, **kwargs):
         # Rate limit is 'max_request' requests per 'min_time' seconds
-        max_requests = 30
+        max_requests = 20
         min_time = 120
 
         now = time.time()

--- a/amf_check_writer/download_from_drive.py
+++ b/amf_check_writer/download_from_drive.py
@@ -312,7 +312,7 @@ class SheetDownloader(object):
                 self.write_values_to_tsv(
                     self.get_sheet_values(sheet_id, cell_range), out_file
                 )
-
+        """
         # Check the expected worksheet files were processed
         # For general (relating to all products) spreadsheets
         if sheet_name.startswith("_"):
@@ -335,7 +335,7 @@ class SheetDownloader(object):
                     f"[ERROR] Could not find/process product-specific worksheets "
                     f"for '{sheet_name}'. Missing: {required.difference(worksheets)}"
                 )
-
+        """
         # Now download the raw spreadsheet
         spreadsheet_file = os.path.join(spreadsheet_dir, sheet_name)
 

--- a/amf_check_writer/download_from_drive.py
+++ b/amf_check_writer/download_from_drive.py
@@ -274,13 +274,13 @@ class SheetDownloader(object):
                 len(results["sheets"]), self.out_dir
             )
         )
-        sheet_name_no_xlsx = sheet_name[:-5]
+        sheet_name_no_xlsx = sheet_name[:-5] if sheet_name.endswith(".xlsx") else sheet_name
 
         # Validate sheet name
-        if sheet_name_no_xlsx + ".xlsx" != sheet_name:
-            raise Exception(
-                f"[ERROR] Sheet does not have expected name with '.xlsx' extension: {sheet_name}"
-            )
+#        if sheet_name_no_xlsx + ".xlsx" != sheet_name:
+#            raise Exception(
+#                f"[ERROR] Sheet does not have expected name with '.xlsx' extension: {sheet_name}"
+#            )
 
         prod_def_dir = os.path.join(parent_folder, "product-definitions")
         tsv_dir = os.path.join(prod_def_dir, "tsv", sheet_name_no_xlsx)

--- a/amf_check_writer/download_from_drive.py
+++ b/amf_check_writer/download_from_drive.py
@@ -202,7 +202,7 @@ class SheetDownloader(object):
                     print(f"[INFO] Found and using '{fname}'")
                 else:
                     print(
-                        f"[INFO] Skipping folder with '{fname}' as we want version '{self.version}' or vocab '{self.vocab}'"
+                        f"[INFO] Skipping folder with '{fname}' as we want {f'version `{self.version}`' if self.version else f'vocab `{self.vocab}`'}"
                     )
                     continue
 

--- a/amf_check_writer/spreadsheet_handler.py
+++ b/amf_check_writer/spreadsheet_handler.py
@@ -33,6 +33,7 @@ class DeploymentModes(Enum):
 SPREADSHEET_NAMES = {
     "common_spreadsheet": "_common",
     "vocabs_spreadsheet": "_vocabularies",
+    "instrument_vocabs_spreadsheet": "_instrument_vocabs",
     "global_attrs_worksheet": "global-attributes.tsv",
     "ncas_instruments_worksheet": "ncas-instrument-name-and-descriptors.tsv",
     "community_instruments_worksheet": "community-instrument-name-and-descriptors.tsv",
@@ -65,8 +66,9 @@ class SpreadsheetHandler(object):
         "global-attributes": {"name": "global-attributes", "cls": GlobalAttrCheck}
     }
 
-    def __init__(self, version_dir):
+    def __init__(self, version_dir, version_or_vocab):
         self.path = version_dir
+        self.version_or_vocab = version_or_vocab
 
     def write_cvs(self, output_dir, write_pyessv=True, pyessv_root=None):
         """
@@ -76,9 +78,15 @@ class SpreadsheetHandler(object):
         :param pyessv_root:  directory to use as pyessv archive
         """
         cvs = list(self.get_all_cvs())
-        version_number = self._find_version_number(output_dir)
+        #if "/vocabs/" in output_dir:
+        #    version_number = "vocabs"
+        #else:
+        if self.version_or_vocab == "version":
+            version_number = self._find_version_number(output_dir)
+        else:
+            version_number = "vocabs"
         self._write_output_files(cvs, BaseCV.to_json, output_dir, "json", version_number)
-
+        
         # Check that correct CVs were written
         json_files = {cv.get_filename("json") for cv in cvs}
 
@@ -98,8 +106,10 @@ class SpreadsheetHandler(object):
 
         if not expected_common_files.issubset(json_files):
             diff = expected_common_files.difference(json_files)
-            raise ValueError(f"[ERROR] The following expected JSON controlled "
-                             f"vocabulary JSON files were not created: {diff}.")
+            if not version_number == "vocabs":
+                if float(version_number[1:]) <= 2.0 or not diff == set(('AMF_ncas_instrument.json', 'AMF_community_instrument.json')):
+                    raise ValueError(f"[ERROR] The following expected JSON controlled "
+                                 f"vocabulary JSON files were not created: {diff}.")
 
         product_ga_and_dim_files = {json for json in json_files 
             if json.startswith("AMF_product_") and "common" not in json and
@@ -109,7 +119,7 @@ class SpreadsheetHandler(object):
             diff = product_ga_and_dim_files.difference(optional_product_files)
             raise ValueError(f"[ERROR] The following expected JSON controlled "
                              f"vocabulary JSON files were not created: {diff}.")
-
+        
         # Write as PYESSV format if required
         if write_pyessv:
             writer = PyessvWriter(pyessv_root=pyessv_root)
@@ -246,45 +256,68 @@ class SpreadsheetHandler(object):
         :return:           an iterator of instances of subclasses of `BaseCV`
         """
         # Static CVs
-        def static_path(name):
-            return os.path.join('product-definitions/tsv', SPREADSHEET_NAMES["vocabs_spreadsheet"],
-                                SPREADSHEET_NAMES[name])
-        cv_parse_infos = [
-            CVParseInfo(
-                path=static_path("ncas_instruments_worksheet"),
-                cls=InstrumentsCV,
-                facets=["ncas_instrument"]
-            ),
-            CVParseInfo(
-                path=static_path("community_instruments_worksheet"),
-                cls=InstrumentsCV,
-                facets=["community_instrument"]
-            ),
-            CVParseInfo(
-                path=static_path("data_products_worksheet"),
-                cls=ProductsCV,
-                facets=["product"]
-            ),
-            CVParseInfo(
-                path=static_path("platforms_worksheet"),
-                cls=PlatformsCV,
-                facets=["platform"]
-            ),
-            CVParseInfo(
-                path=static_path("scientists_worksheet"),
-                cls=ScientistsCV,
-                facets=["scientist"]
-            )
-        ]
+        def static_path(name, vocabs=None):
+            if vocabs:
+                return os.path.join('product-definitions/tsv', SPREADSHEET_NAMES[vocabs], SPREADSHEET_NAMES[name])
+            else:
+                return os.path.join('product-definitions/tsv', SPREADSHEET_NAMES["vocabs_spreadsheet"],
+                                    SPREADSHEET_NAMES[name])
+        
+        if self.version_or_vocab == "version":
+            cv_parse_infos = [
+                CVParseInfo(
+                    path=static_path("ncas_instruments_worksheet"),
+                    cls=InstrumentsCV,
+                    facets=["ncas_instrument"]
+                ),
+                CVParseInfo(
+                    path=static_path("community_instruments_worksheet"),
+                    cls=InstrumentsCV,
+                    facets=["community_instrument"]
+                ),
+                CVParseInfo(
+                    path=static_path("data_products_worksheet"),
+                    cls=ProductsCV,
+                    facets=["product"]
+                ),
+                CVParseInfo(
+                    path=static_path("platforms_worksheet"),
+                    cls=PlatformsCV,
+                    facets=["platform"]
+                ),
+                CVParseInfo(
+                    path=static_path("scientists_worksheet"),
+                    cls=ScientistsCV,
+                    facets=["scientist"]
+                )
+            ]
+            cv_parse_infos += self._get_common_var_dim_parse_info()
+            per_product_cvs = list(self._get_per_product_parse_info())
+            cv_parse_infos += per_product_cvs
 
-        cv_parse_infos += self._get_common_var_dim_parse_info()
-        per_product_cvs = list(self._get_per_product_parse_info())
-        cv_parse_infos += per_product_cvs
+            if not per_product_cvs:
+                print(f"[WARNING] No product variable/dimension spreadsheets found in {self.path}",
+                    file=sys.stderr
+                )
 
-        if not per_product_cvs:
-            print(f"[WARNING] No product variable/dimension spreadsheets found in {self.path}",
-                file=sys.stderr
-            )
+        elif self.version_or_vocab == "instruments":
+            cv_parse_infos = [
+                CVParseInfo(
+                    path=static_path("ncas_instruments_worksheet", vocabs="instrument_vocabs_spreadsheet"),
+                    cls=InstrumentsCV,
+                    facets=["ncas_instrument"]
+                ),
+                CVParseInfo(
+                    path=static_path("community_instruments_worksheet", vocabs="instrument_vocabs_spreadsheet"),
+                    cls=InstrumentsCV,
+                    facets=["community_instrument"]
+                ),
+            ]
+            self.product_names = []
+        
+        else:
+            raise ValueError(f"Vocab {self.version_or_vocab} doesn't exist (how did we get here?)")
+
 
         for count, (path, cls, facets) in enumerate(cv_parse_infos):
             if base_class and base_class not in cls.__bases__:
@@ -320,7 +353,7 @@ class SpreadsheetHandler(object):
         sheet_regex = re.compile(
             r"/tsv/(?P<name>[a-zA-Z0-9-]+)/(?P<type>variables|dimensions|global-attributes)-specific\.tsv$"
         )
-        ignore_match = re.compile(r"/(_common|_vocabularies)/")
+        ignore_match = re.compile(r"/(_common|_vocabularies|_instrument_vocabs)/")
 
         prods_dir = os.path.join(self.path, 'product-definitions/tsv')
 

--- a/amf_check_writer/spreadsheet_handler.py
+++ b/amf_check_writer/spreadsheet_handler.py
@@ -33,8 +33,10 @@ class DeploymentModes(Enum):
 SPREADSHEET_NAMES = {
     "common_spreadsheet": "_common",
     "vocabs_spreadsheet": "_vocabularies",
+    "platform_vocabs_spreadsheet": "_platform_vocabs",
     "instrument_vocabs_spreadsheet": "_instrument_vocabs",
     "global_attrs_worksheet": "global-attributes.tsv",
+    "platform_worksheet": "platforms.tsv",
     "ncas_instruments_worksheet": "ncas-instrument-name-and-descriptors.tsv",
     "community_instruments_worksheet": "community-instrument-name-and-descriptors.tsv",
     "data_products_worksheet": "data-products.tsv",
@@ -311,6 +313,16 @@ class SpreadsheetHandler(object):
                     path=static_path("community_instruments_worksheet", vocabs="instrument_vocabs_spreadsheet"),
                     cls=InstrumentsCV,
                     facets=["community_instrument"]
+                ),
+            ]
+            self.product_names = []
+
+        elif self.version_or_vocab == "platforms":
+            cv_parse_infos = [
+                CVParseInfo(
+                    path=static_path("platform_worksheet", vocabs="platform_vocabs_spreadsheet"),
+                    cls=PlatformsCV,
+                    facets=["platform"]
                 ),
             ]
             self.product_names = []

--- a/amf_check_writer/spreadsheet_handler.py
+++ b/amf_check_writer/spreadsheet_handler.py
@@ -109,7 +109,7 @@ class SpreadsheetHandler(object):
         if not expected_common_files.issubset(json_files):
             diff = expected_common_files.difference(json_files)
             if not version_number == "vocabs":
-                if float(version_number[1:]) <= 2.0 or not diff == set(('AMF_ncas_instrument.json', 'AMF_community_instrument.json')):
+                if (float(version_number[1:]) <= 2.0 and len(diff) != 0) or (float(version_number[1:]) >= 2.1 and not diff == set(('AMF_ncas_instrument.json', 'AMF_community_instrument.json', 'AMF_platform.json'))):
                     raise ValueError(f"[ERROR] The following expected JSON controlled "
                                  f"vocabulary JSON files were not created: {diff}.")
 

--- a/amf_check_writer/workflow_data.yml
+++ b/amf_check_writer/workflow_data.yml
@@ -23,6 +23,9 @@ google_drive_content:
     - platforms
     - creators
     - file-naming
+  _instrument_vocabs.xlsx:
+    - community-instrument-name-and-descriptors
+    - ncas-instrument-name-and-descriptors
   per-product:
     - dimensions-specific 
     - global-attributes-specific*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 google-api-python-client
 httplib2
+google-auth
+google-auth-oauthlib
 oauth2client
 pyasn1
 pyasn1-modules

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ uritemplate
 pyessv
 enum34
 netCDF4
-pygdrive3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,4 @@ rsa
 six
 uritemplate
 pyessv
-enum34
 netCDF4


### PR DESCRIPTION
I have made some changes mostly related to the location of the spreadsheets on Google that are being downloaded.
- The spreadsheets have moved to a shared drive, rather than a folder in a personal drive. This means some new folder IDs have had to be added, and downloading from a shared drive requires the drive ID as well as the folder ID
- The instrument and platform sheets have been separated out from the ncas-general folders they were previously in into a new vocabularies folder. I have added the option to download a vocabulary as well as, or instead of, a version of the NCAS-GENERAL spreadsheets.
- Added v2.1a for downloading - this will soon change to v2.1 but a separate request will change that.
- The `oauth2client` module is deprecated, I have used this opportunity to switch to `google-auth` and `google-auth-oauthlib` - authentication still works the same way.
- Also removed a couple of other modules from the requirements file as these are no longer needed.